### PR TITLE
fix theme toggle and restore utility page styles

### DIFF
--- a/src/auth.html
+++ b/src/auth.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/main.css" />
     <link rel="stylesheet" href="/css/global.css" />
+    <link rel="stylesheet" href="/css/landing-v2.css" />
     <link rel="stylesheet" href="/css/login.css" />
   </head>
   <body class="page-transition">

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -72,7 +72,7 @@
   --space-3xl: 4rem;
 }
 
-[data-theme='dark'] {
+[data-theme='light'] {
   --color-bg-primary: #f8fafc;
   --color-bg-secondary: #e2e8f0;
   --color-bg-tertiary: #cbd5f5;

--- a/src/css/landing-v2.css
+++ b/src/css/landing-v2.css
@@ -437,3 +437,425 @@ main {
     transform: none;
   }
 }
+
+/* ==========================================
+   Utility Pages - Success, Error, Legal, Auth
+   ========================================== */
+.success-container,
+.error-container {
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xl) var(--space-md);
+}
+
+.success-box,
+.error-box {
+  max-width: 640px;
+  width: 100%;
+  text-align: center;
+  padding: var(--space-3xl) var(--space-2xl);
+}
+
+.success-icon,
+.error-icon {
+  margin: 0 auto var(--space-xl);
+  animation: scaleIn 0.5s var(--ease-out);
+}
+
+.success-icon svg {
+  color: var(--success);
+}
+
+.error-icon svg {
+  color: var(--error);
+}
+
+.error-code {
+  font-size: clamp(4rem, 10vw, 8rem);
+  font-weight: 900;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-light));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1;
+  margin-bottom: var(--space-lg);
+}
+
+.success-box h1,
+.error-box h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: var(--space-lg);
+}
+
+.success-container .success-message,
+.error-container .error-message {
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-2xl);
+  line-height: var(--leading-relaxed);
+}
+
+.success-details {
+  margin: var(--space-2xl) 0;
+  text-align: left;
+  padding: var(--space-xl);
+}
+
+.success-details h2 {
+  font-size: var(--text-xl);
+  margin-bottom: var(--space-lg);
+}
+
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.detail-row:last-child {
+  border-bottom: none;
+}
+
+.status-badge {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--success);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+}
+
+.success-actions,
+.error-actions {
+  display: flex;
+  gap: var(--space-md);
+  justify-content: center;
+  margin: var(--space-2xl) 0 var(--space-lg);
+}
+
+.error-suggestions {
+  margin: var(--space-2xl) 0;
+  text-align: left;
+  padding: var(--space-xl);
+}
+
+.error-suggestions h2 {
+  font-size: var(--text-xl);
+  margin-bottom: var(--space-md);
+}
+
+.error-suggestions ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.error-suggestions li {
+  padding: 0.5rem 0;
+  color: var(--color-text-secondary);
+}
+
+.success-footer,
+.error-footer {
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-xl);
+  border-top: 1px solid var(--glass-border);
+  color: var(--color-text-tertiary);
+}
+
+/* Legal Pages */
+.legal-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-md);
+}
+
+.legal-content {
+  padding: var(--space-3xl) var(--space-2xl);
+}
+
+.legal-content h1 {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  margin-bottom: var(--space-sm);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.last-updated {
+  color: var(--color-text-tertiary);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-2xl);
+}
+
+.legal-content section {
+  margin-bottom: var(--space-2xl);
+}
+
+.legal-content h2 {
+  font-size: var(--text-2xl);
+  margin-bottom: var(--space-md);
+}
+
+.legal-content h3 {
+  font-size: var(--text-xl);
+  margin-bottom: var(--space-sm);
+}
+
+.legal-content p {
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-md);
+}
+
+.legal-content ul {
+  list-style: disc;
+  padding-left: 1.75rem;
+  margin-bottom: var(--space-lg);
+}
+
+.legal-content li {
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  margin-bottom: 0.5rem;
+}
+
+/* Auth Page */
+.auth-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3xl) var(--space-md);
+  position: relative;
+}
+
+.auth-main {
+  max-width: 520px;
+  width: 100%;
+  z-index: 1;
+}
+
+.auth-box {
+  padding: var(--space-3xl) var(--space-2xl);
+}
+
+.auth-header {
+  text-align: center;
+  margin-bottom: var(--space-2xl);
+}
+
+.auth-header p {
+  color: var(--color-text-secondary);
+}
+
+.oauth-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+
+.btn-oauth {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  width: 100%;
+  padding: 0.85rem 1.5rem;
+  background: var(--glass-bg-light);
+  border: 1px solid var(--glass-border);
+  transition: all var(--duration-base) var(--ease-out);
+}
+
+.btn-oauth:hover {
+  background: var(--glass-bg-medium);
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: translateY(-2px);
+}
+
+.divider {
+  position: relative;
+  text-align: center;
+  margin: var(--space-xl) 0;
+}
+
+.divider::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--glass-border);
+}
+
+.divider span {
+  position: relative;
+  background: var(--glass-bg);
+  padding: 0 var(--space-sm);
+  color: var(--color-text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.auth-tabs {
+  display: flex;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xl);
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.tab-btn {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color var(--duration-base) var(--ease-out), border-color var(--duration-base) var(--ease-out);
+}
+
+.tab-btn.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.tab-btn:hover:not(.active) {
+  color: var(--color-text-secondary);
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+  animation: fadeIn 0.3s var(--ease-out);
+}
+
+.auth-hint {
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  text-align: center;
+  margin-top: var(--space-sm);
+}
+
+.form-footer {
+  text-align: right;
+  margin-bottom: var(--space-md);
+}
+
+.link-secondary {
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+  transition: color var(--duration-base) var(--ease-out);
+}
+
+.link-secondary:hover {
+  color: var(--color-primary-light);
+}
+
+.btn-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.spinner-small {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.auth-footer {
+  text-align: center;
+  margin-top: var(--space-xl);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--glass-border);
+  color: var(--color-text-tertiary);
+}
+
+.auth-visual {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.visual-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.18;
+  animation: float 8s ease-in-out infinite;
+}
+
+.visual-orb.orb-1 {
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle, var(--color-primary), transparent);
+  top: -150px;
+  right: -150px;
+}
+
+.visual-orb.orb-2 {
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, var(--color-secondary), transparent);
+  bottom: -100px;
+  left: -100px;
+  animation-delay: 3s;
+}
+
+.visual-orb.orb-3 {
+  width: 350px;
+  height: 350px;
+  background: radial-gradient(circle, var(--color-primary-light), transparent);
+  top: 50%;
+  left: 50%;
+  animation-delay: 6s;
+}
+
+@keyframes scaleIn {
+  from {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .success-actions,
+  .error-actions {
+    flex-direction: column;
+  }
+
+  .success-actions .btn,
+  .error-actions .btn {
+    width: 100%;
+  }
+
+  .legal-content,
+  .auth-box {
+    padding: var(--space-2xl) var(--space-lg);
+  }
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -95,8 +95,8 @@
   --z-tooltip: 1500;
 }
 
-/* Dark Mode Variables */
-[data-theme="dark"] {
+/* Light Mode Variables */
+[data-theme="light"] {
   --glass-bg-light: rgba(255, 255, 255, 0.85);
   --glass-bg-medium: rgba(255, 255, 255, 0.9);
   --glass-bg-heavy: rgba(255, 255, 255, 0.95);

--- a/src/js/ui-utils.js
+++ b/src/js/ui-utils.js
@@ -10,8 +10,8 @@
   const darkModeToggle = document.getElementById('dark-mode-toggle');
   if (!darkModeToggle) return;
 
-  // Check for saved theme preference or default to light mode
-  const currentTheme = localStorage.getItem('theme') || 'light';
+  // Check for saved theme preference or default to dark mode
+  const currentTheme = localStorage.getItem('theme') || 'dark';
   document.documentElement.setAttribute('data-theme', currentTheme);
   darkModeToggle.setAttribute('aria-pressed', currentTheme === 'dark');
 


### PR DESCRIPTION
## Summary
- align the dark/light theme attribute names across the global tokens, main design system, and toggle script so “dark mode” once again refers to the dark palette
- bring back the success, error, legal, and auth utility styles with updated glass variables and ensure auth.html loads the stylesheet they live in

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bb4be336c832e8253815270ceabf8)