### PR TITLE
Align landing page branding and pricing tiers

### DIFF
--- a/src/css/landing-v2.css
+++ b/src/css/landing-v2.css
@@ -1,4 +1,4 @@
-/* Koloni Landing Page - EqtyLab inspired premium system */
+/* Koloni Landing Page - AdGenXAI premium system */
 
 header[role='banner'] {
   position: relative;
@@ -329,8 +329,10 @@ main {
 
 .pricing-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .pricing-card {
@@ -338,23 +340,49 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  position: relative;
+  transition: transform var(--duration-base) var(--ease-out), box-shadow var(--duration-base) var(--ease-out);
 }
 
-.pricing-popular {
-  transform: scale(1.03);
+.pricing-card:hover {
+  transform: translateY(-4px);
+}
+
+.pricing-card.popular {
+  transform: scale(1.05);
+  border: 1px solid var(--color-primary);
+  box-shadow: 0 0 40px rgba(14, 165, 233, 0.3);
+}
+
+.pricing-card.popular:hover {
+  transform: scale(1.05) translateY(-4px);
+}
+
+.pricing-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .pricing-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
   font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
   color: var(--color-text-tertiary);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .pricing-badge.popular {
   background: var(--gradient-primary);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: white;
+  border: none;
 }
 
 .pricing-price {
@@ -433,8 +461,14 @@ main {
     padding: 1.5rem;
   }
 
-  .pricing-popular {
+  .pricing-card.popular {
     transform: none;
+  }
+}
+
+@media (max-width: 1200px) {
+  .pricing-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -37,14 +37,14 @@
             <span aria-hidden="true">🌓</span>
           </button>
         </div>
-        <div class="hero-badge">Now shipping EqtyLab-grade workflows</div>
+        <div class="hero-badge">Now shipping AdGenXAI-grade workflows</div>
         <h1 class="hero-title">
           Transform Your Content Creation with
-          <span class="gradient-text">premium AI precision</span>
+          <span class="gradient-text">AI</span>
         </h1>
         <p class="hero-subtitle">
-          Generate cinematic LongCat and Emu stories with real glassmorphic polish.
-          Export everywhere in seconds with platform-perfect fidelity.
+          Generate cinematic LongCat and Emu content in seconds. Export everywhere with
+          platform-perfect formatting.
         </p>
         <div class="hero-cta">
           <a href="/signup.html" class="btn btn-primary btn-lg" aria-label="Start creating for free">
@@ -55,7 +55,7 @@
           </a>
         </div>
         <div class="hero-trust">
-          <span>Trusted by 10,000+ creators</span>
+          <span>Join thousands of creators using AdGenXAI</span>
           <ul class="trust-logos" aria-label="Partner logos">
             <li>CreatorForge</li>
             <li>SignalWave</li>
@@ -173,48 +173,58 @@
       <section class="pricing section" aria-labelledby="pricing-heading" id="pricing">
         <h2 id="pricing-heading">Flexible pricing for every hive</h2>
         <div class="pricing-grid">
-          <article class="glass-card pricing-card">
-            <span class="pricing-badge">Starter</span>
+          <article class="glass-card pricing-card" aria-label="Starter plan">
+            <div class="pricing-card-header">
+              <span class="pricing-badge">Starter</span>
+              <p class="pricing-description">Perfect for individuals just getting started.</p>
+            </div>
             <h3 class="pricing-price">$9<span>/month</span></h3>
-            <p class="pricing-description">Perfect for individuals shipping daily content.</p>
             <ul class="pricing-features">
               <li><span class="icon">✓</span> 100 generations / month</li>
-              <li><span class="icon">✓</span> LongCat + Emu formats</li>
-              <li><span class="icon">✓</span> Platform exports</li>
+              <li><span class="icon">✓</span> All formats (LongCat, Emu)</li>
+              <li><span class="icon">✓</span> Instagram &amp; YouTube export</li>
               <li><span class="icon">✓</span> Email support</li>
+              <li><span class="icon">✓</span> Basic analytics</li>
             </ul>
-            <a href="/pricing.html" class="btn btn-glass btn-full">Get Started</a>
+            <a href="/pricing.html" class="btn btn-primary btn-full">Choose Plan</a>
           </article>
-          <article class="glass-card-glow pricing-card pricing-popular">
-            <span class="pricing-badge popular">Most Popular</span>
+          <article class="glass-card pricing-card popular" aria-label="Pro plan">
+            <div class="pricing-card-header">
+              <span class="pricing-badge popular">Most Popular</span>
+              <p class="pricing-description">Built for teams that ship premium content daily.</p>
+            </div>
             <h3 class="pricing-price">$29<span>/month</span></h3>
-            <p class="pricing-description">For serious creators who need premium control.</p>
             <ul class="pricing-features">
               <li><span class="icon">✓</span> 500 generations / month</li>
-              <li><span class="icon">✓</span> Unlimited exports</li>
-              <li><span class="icon">✓</span> Advanced analytics</li>
+              <li><span class="icon">✓</span> All formats (LongCat, Emu)</li>
+              <li><span class="icon">✓</span> All export formats</li>
               <li><span class="icon">✓</span> Priority support</li>
-              <li><span class="icon">✓</span> Collaboration seats</li>
+              <li><span class="icon">✓</span> Advanced analytics</li>
+              <li><span class="icon">✓</span> Team collaboration</li>
             </ul>
-            <a href="/pricing.html" class="btn btn-primary btn-full">Start Creating</a>
+            <a href="/pricing.html" class="btn btn-primary btn-full">Get Started</a>
           </article>
-          <article class="glass-card pricing-card">
-            <span class="pricing-badge">Enterprise</span>
+          <article class="glass-card pricing-card" aria-label="Enterprise plan">
+            <div class="pricing-card-header">
+              <span class="pricing-badge">Enterprise</span>
+              <p class="pricing-description">Custom control, governance, and concierge support.</p>
+            </div>
             <h3 class="pricing-price">$99<span>/month</span></h3>
-            <p class="pricing-description">Scale across teams with governance baked in.</p>
             <ul class="pricing-features">
               <li><span class="icon">✓</span> Unlimited generations</li>
+              <li><span class="icon">✓</span> All formats &amp; exports</li>
+              <li><span class="icon">✓</span> 24/7 priority support</li>
               <li><span class="icon">✓</span> Custom integrations</li>
-              <li><span class="icon">✓</span> Dedicated strategist</li>
-              <li><span class="icon">✓</span> 24/7 white-glove support</li>
+              <li><span class="icon">✓</span> Dedicated account manager</li>
+              <li><span class="icon">✓</span> API access</li>
             </ul>
-            <a href="/pricing.html" class="btn btn-glass btn-full">Talk to Sales</a>
+            <a href="/pricing.html" class="btn btn-primary btn-full">Choose Plan</a>
           </article>
         </div>
       </section>
       <section class="final-cta section glass-panel" aria-labelledby="cta-heading">
-        <h2 id="cta-heading">Ready to build with EqtyLab precision?</h2>
-        <p>Join thousands of creators who trust AdGenXAI for glassmorphic, platform-ready stories.</p>
+        <h2 id="cta-heading">Ready to Transform Your Content?</h2>
+        <p>Join thousands of creators using AdGenXAI for premium AI-powered content generation.</p>
         <div class="cta-buttons">
           <a href="/signup.html" class="btn btn-primary btn-lg" aria-label="Sign up for free">Get Started Free</a>
           <a href="#pricing" class="btn btn-glass btn-lg" aria-label="View pricing plans">View Pricing</a>


### PR DESCRIPTION
## Summary
- remove remaining EqtyLab references, refresh the hero copy, and update CTA messaging to match the AdGenXAI brand voice
- rebuild the pricing grid to feature Starter, Pro, and Enterprise tiers with the requested feature lists, highlight styling, and gradient calls to action
- refine the pricing styles for glassmorphic consistency, better spacing, and responsive behavior so the Pro plan is elevated on desktop and still clean on mobile

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config.js file)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bc0e2205c832e8b2332a94db937bd)